### PR TITLE
Added Pixelate operation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gio"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,6 +451,7 @@ dependencies = [
  "libc",
  "once_cell",
  "pangocairo",
+ "rand",
  "thiserror",
  "tracing",
  "tracing-subscriber",
@@ -612,6 +624,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c9b1041b4387893b91ee6746cddfc28516aff326a3519fb2adf820932c5e6cb"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +679,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,5 @@ libc = "0.2.104"
 tracing = "0.1.23"
 tracing-subscriber = "0.2.15"
 thiserror = "1.0.30"
+
+rand = "0.8.4"

--- a/src/editor/underlying.rs
+++ b/src/editor/underlying.rs
@@ -139,6 +139,17 @@ impl EditorWindow {
         }
         .execute(image, cairo));
 
+        op!(Operation::Pixelate {
+            rect: Rectangle {
+                x: 400.0,
+                y: 400.0,
+                w: 200.0,
+                h: 200.0
+            },
+            seed: 12345,
+        }
+        .execute(image, cairo));
+
         let font_description = FontDescription::from_string("Fira Code, 40pt");
 
         op!(Operation::Text {


### PR DESCRIPTION
It works by grouping the pixels in the rectangle into bigger boxes, and then replacing every pixel inside of the box by a random sample inside of it.

Note that we seed the RNG so the same pixelation is always displayed in every update. 

Also note that, same as blur, it will not work with other things drawn by the same program, like an ellipse for instance. 