### PR TITLE
Fixed Text to enable varying position

### DIFF
--- a/src/editor/operations.rs
+++ b/src/editor/operations.rs
@@ -66,6 +66,7 @@ pub enum Operation {
         fill: Colour,
     },
     Text {
+        top_left: Point,
         text: String,
         colour: Colour,
         font_description: FontDescription,
@@ -138,6 +139,7 @@ impl Operation {
                 draw_rectangle(cairo, rect, *border, *fill)?;
             }
             Operation::Text {
+                top_left: Point { x, y },
                 text,
                 colour,
                 font_description,
@@ -148,7 +150,7 @@ impl Operation {
 
                 layout.set_markup(text);
                 layout.set_font_description(Some(font_description));
-                cairo.move_to(1000.0, 420.0);
+                cairo.move_to(*x, *y);
                 cairo.set_source_colour(*colour);
                 pangocairo::update_layout(cairo, &layout);
                 pangocairo::show_layout(cairo, &layout);

--- a/src/editor/underlying.rs
+++ b/src/editor/underlying.rs
@@ -152,6 +152,10 @@ impl EditorWindow {
         let font_description = FontDescription::from_string("Fira Code, 40pt");
 
         op!(Operation::Text {
+            top_left: Point {
+                x: 1000.0,
+                y: 420.0,
+            },
             text: "<b>hello</b> <i>world</i>".into(),
             colour: Colour {
                 red: 0,


### PR DESCRIPTION
Drawing `Text` was fixed to the (1000.0, 420.0) point, probably an oversight while trying to get it to work. 
This PR fixes it, by adding a new parameter to the `Text` variant, `top_left`.