### PR TITLE
Added Number Bubbles

### DIFF
--- a/src/editor/operations.rs
+++ b/src/editor/operations.rs
@@ -41,6 +41,8 @@ const ARROWHEAD_LENGTH_RATIO: f64 = 0.1;
 const ARROWHEAD_APERTURE: f64 = PI / 6.0;
 /// How big will pixelate boxes be, in this case, we will group the rectangle into 4x4 boxes, which we will set all of its pixels to the same value
 const PIXELATE_SIZE: u64 = 4;
+/// How big the bubbles will be
+const BUBBLE_RADIUS: f64 = 10.0;
 
 #[derive(Clone, Debug)]
 pub enum Operation {
@@ -83,6 +85,13 @@ pub enum Operation {
         ellipse: Ellipse,
         border: Colour,
         fill: Colour,
+    },
+    Bubble {
+        centre: Point,
+        bubble_colour: Colour,
+        text_colour: Colour,
+        number: i32,
+        font_description: FontDescription,
     },
 }
 
@@ -166,6 +175,33 @@ impl Operation {
                 cairo.save()?;
                 draw_ellipse(cairo, ellipse, *border, *fill)?;
                 cairo.restore()?;
+            }
+            Operation::Bubble {
+                centre,
+                bubble_colour,
+                text_colour,
+                number,
+                font_description,
+            } => {
+                info!("Bubble");
+                let Point { x, y } = centre;
+                let num_str = number.to_string();
+
+                let ellipse = Ellipse {
+                    x: x - BUBBLE_RADIUS,
+                    y: y - BUBBLE_RADIUS,
+                    w: 2.0 * BUBBLE_RADIUS,
+                    h: 2.0 * BUBBLE_RADIUS,
+                };
+
+                draw_ellipse(cairo, &ellipse, INVISIBLE, *bubble_colour)?;
+                draw_text_centred_at(
+                    cairo,
+                    centre,
+                    num_str.as_str(),
+                    *text_colour,
+                    font_description,
+                )?;
             }
         };
 

--- a/src/editor/operations.rs
+++ b/src/editor/operations.rs
@@ -164,22 +164,7 @@ impl Operation {
             } => {
                 info!("Ellipse");
                 cairo.save()?;
-
-                cairo.save()?;
-                // 1. Position our ellipse at (x, y)
-                cairo.translate(ellipse.x, ellipse.y);
-                // 2. Scale its x coordinates by w, and its y coordinates by h
-                cairo.scale(ellipse.w, ellipse.h);
-                // 3. Create it by faking a circle on [0,1]x[0,1] centered on (0.5, 0.5)
-                cairo.arc(0.5, 0.5, 1.0, 0.0, 2.0 * PI);
-                cairo.set_source_colour(*fill);
-                cairo.fill_preserve()?;
-                cairo.restore()?;
-
-                cairo.set_source_colour(*border);
-                // 4. Draw a border arround it
-                cairo.stroke()?;
-
+                draw_ellipse(cairo, ellipse, *border, *fill)?;
                 cairo.restore()?;
             }
         };
@@ -240,6 +225,30 @@ fn draw_rectangle(
     cairo.set_source_colour(border);
     cairo.stroke()?;
     cairo.restore()?;
+
+    Ok(())
+}
+
+fn draw_ellipse(
+    cairo: &Context,
+    ellipse: &Ellipse,
+    border: Colour,
+    fill: Colour,
+) -> Result<(), Error> {
+    cairo.save()?;
+    // 1. Position our ellipse at (x, y)
+    cairo.translate(ellipse.x, ellipse.y);
+    // 2. Scale its x coordinates by w, and its y coordinates by h
+    cairo.scale(ellipse.w, ellipse.h);
+    // 3. Create it by faking a circle on [0,1]x[0,1] centered on (0.5, 0.5)
+    cairo.arc(0.5, 0.5, 1.0, 0.0, 2.0 * PI);
+    cairo.set_source_colour(fill);
+    cairo.fill_preserve()?;
+    cairo.restore()?;
+
+    cairo.set_source_colour(border);
+    // 4. Draw a border arround it
+    cairo.stroke()?;
 
     Ok(())
 }

--- a/src/editor/underlying.rs
+++ b/src/editor/underlying.rs
@@ -163,6 +163,25 @@ impl EditorWindow {
                 blue: 0,
                 alpha: 255
             },
+            font_description: font_description.clone()
+        }
+        .execute(image, cairo));
+
+        op!(Operation::Bubble {
+            centre: Point { x: 600.0, y: 600.0 },
+            bubble_colour: Colour {
+                red: 0,
+                green: 0,
+                blue: 255,
+                alpha: 255
+            },
+            text_colour: Colour {
+                red: 0,
+                green: 0,
+                blue: 0,
+                alpha: 255
+            },
+            number: 123,
             font_description
         }
         .execute(image, cairo));


### PR DESCRIPTION
The idea of this PR is to add a way to draw bubbles in an easy way, so in the future it can be done to get something similar to Flameshot's autoincrement bubbles. 

Here is an example from Flameshot:
![image](https://user-images.githubusercontent.com/43870496/139513821-d264aa5f-440b-484b-b472-05f1fbf67915.png)

The idea for this is to have an easy way to mark an order/sequence things should be read in.

For this, I also added the functions `draw_text_at()`, `draw_text_centred_at()` and `draw_ellipse()`, which just move preexisting code to their own functions.