### PR TITLE
Fixed arrowhead bug

### DIFF
--- a/src/editor/operations.rs
+++ b/src/editor/operations.rs
@@ -454,7 +454,7 @@ fn draw_arrow(cairo: &Context, start: Point, end: Point, colour: Colour) -> Resu
 
 fn get_line_angle(start: Point, end: Point) -> f64 {
     let Point { x, y } = end.to_owned() - start.to_owned();
-    (y / x).atan()
+    y.atan2(x)
 }
 
 fn draw_text_at(

--- a/src/editor/operations/data/point.rs
+++ b/src/editor/operations/data/point.rs
@@ -14,7 +14,7 @@ impl From<(f64, f64)> for Point {
 
 impl Point {
     pub fn dist(&self) -> f64 {
-        (self.x * self.x + self.y + self.y).sqrt()
+        (self.x * self.x + self.y * self.y).sqrt()
     }
 }
 


### PR DESCRIPTION
This two line change PR fixes the arrows behaving weirdly when they were not mostly horizontal, and pointing everywhere but to the right