### PR TITLE
Rework Post capture actions

### DIFF
--- a/resources/kc.kcshot.gschema.xml
+++ b/resources/kc.kcshot.gschema.xml
@@ -10,5 +10,10 @@
             <default>''</default>
             <summary>The path where screenshots are saved. kcshot sets it to ${XDG_DATA_HOME}/kcshot if empty.</summary>
         </key>
+
+        <key name="post-capture-actions" type="as">
+            <default>["copy-to-clipboard", "save-to-disk"]</default>
+            <summary>The actions to be performed, in the order they are to be performed</summary>
+        </key>
     </schema>
 </schemalist>

--- a/src/editor/underlying.rs
+++ b/src/editor/underlying.rs
@@ -23,8 +23,9 @@ use crate::{
     },
     historymodel::ModelNotifier,
     kcshot::KCShot,
-    log_if_err, postcapture,
+    log_if_err
 };
+use crate::postcapture::run_postcapture_actions;
 
 #[derive(Debug)]
 struct Image {
@@ -76,11 +77,8 @@ impl EditorWindow {
 
         match utils::pixbuf_for(&image.surface, rectangle) {
             // Process all post capture actions
-            // TODO: Give the user the option which actions to run and in which order.
             Some(mut pixbuf) => {
-                for action in postcapture::get_postcapture_actions() {
-                    action.handle(model_notifier.clone(), conn, &mut pixbuf)
-                }
+                run_postcapture_actions(model_notifier, conn, &mut pixbuf)
             },
             None => {
                 error!(

--- a/src/editor/underlying.rs
+++ b/src/editor/underlying.rs
@@ -75,8 +75,12 @@ impl EditorWindow {
         window.close();
 
         match utils::pixbuf_for(&image.surface, rectangle) {
-            Some(pixbuf) => {
-                postcapture::current_action().handle(model_notifier.clone(), conn, pixbuf);
+            // Process all post capture actions
+            // TODO: Give the user the option which actions to run and in which order.
+            Some(mut pixbuf) => {
+                for action in postcapture::get_postcapture_actions() {
+                    action.handle(model_notifier.clone(), conn, &mut pixbuf)
+                }
             }
             None => {
                 error!(

--- a/src/editor/underlying.rs
+++ b/src/editor/underlying.rs
@@ -81,7 +81,7 @@ impl EditorWindow {
                 for action in postcapture::get_postcapture_actions() {
                     action.handle(model_notifier.clone(), conn, &mut pixbuf)
                 }
-            }
+            },
             None => {
                 error!(
                     "Failed to create a pixbuf from the surface: {:?} with crop region {rectangle:#?}",

--- a/src/postcapture.rs
+++ b/src/postcapture.rs
@@ -10,6 +10,12 @@ use crate::{
     historymodel::{ModelNotifier, RowData},
 };
 
+pub fn do_postcapture_actions(history_model: &HistoryModel, conn: &SqliteConnection, pixbuf: &mut Pixbuf) {
+    for action in get_postcapture_actions() {
+        action.handle(history_model, conn, pixbuf)
+    }
+}
+
 /// Trait for the post capture actions.
 pub trait PostCaptureAction {
     /// The name of the post capture action.

--- a/src/postcapture.rs
+++ b/src/postcapture.rs
@@ -18,6 +18,9 @@ pub fn do_postcapture_actions(history_model: &HistoryModel, conn: &SqliteConnect
 
 /// Trait for the post capture actions.
 pub trait PostCaptureAction {
+    /// Returns the ID of the action, this is used for the settings.
+    fn id(&self) -> String;
+
     /// The name of the post capture action.
     fn name(&self) -> String;
 
@@ -32,6 +35,10 @@ pub trait PostCaptureAction {
 pub struct SaveToDisk;
 
 impl PostCaptureAction for SaveToDisk {
+    fn id(&self) -> String {
+        "save-to-disk".to_owned()
+    }
+
     fn name(&self) -> String {
         "Save to disk".to_owned()
     }
@@ -74,6 +81,10 @@ impl PostCaptureAction for SaveToDisk {
 pub struct CopyToClipboard;
 
 impl PostCaptureAction for CopyToClipboard {
+    fn id(&self) -> String {
+        "copy-to-clipboard".to_owned()
+    }
+
     fn name(&self) -> String {
         "Copy to clipboard".to_owned()
     }


### PR DESCRIPTION
This PR lays the base for the post capture actions.
Actions are now singular actions that get executed in sequence (configurable in the settings).
Future actions can be easily added by implementing the trait for a struct and then adding it to the list of available post capture actions.