### PR TITLE
Enforce and fix manual_string_new occurrences

### DIFF
--- a/src/editor/display_server.rs
+++ b/src/editor/display_server.rs
@@ -63,12 +63,11 @@ impl WmFeatures {
     }
 
     fn get_impl() -> Result<WmFeatures> {
-        let wayland_display = env::var("WAYLAND_DISPLAY").unwrap_or_else(|_| "".into());
-        let xdg_session_type = env::var("XDG_SESSION_TYPE").unwrap_or_else(|_| "".into());
+        let wayland_display = env::var("WAYLAND_DISPLAY").unwrap_or_default();
+        let xdg_session_type = env::var("XDG_SESSION_TYPE").unwrap_or_default();
         // For checking that Wayland features work even when kcshot is used under X (but on desktops providing
         // the necessary portals)
-        let force_wayland_emulation =
-            env::var("KCSHOT_FORCE_USE_PORTALS").unwrap_or_else(|_| "".into());
+        let force_wayland_emulation = env::var("KCSHOT_FORCE_USE_PORTALS").unwrap_or_default();
 
         let is_wayland = wayland_display.to_lowercase().contains("wayland")
             || xdg_session_type == "wayland"

--- a/src/editor/operations.rs
+++ b/src/editor/operations.rs
@@ -246,7 +246,7 @@ impl Operation {
             }
             Tool::Text => Self::Text {
                 top_left: start,
-                text: "".into(),
+                text: String::new(),
                 // We use secondary colour here as the primary one is more likely to be transparent,
                 // given that's the default, and people are likely to use boxes and ellipses to try
                 // and bring things into attention, and in those situations the primary colour is

--- a/src/systray/sni.rs
+++ b/src/systray/sni.rs
@@ -162,10 +162,10 @@ impl ksni::Tray for Tray {
 
     fn tool_tip(&self) -> ksni::ToolTip {
         ksni::ToolTip {
-            icon_name: "".into(),
+            icon_name: String::new(),
             icon_pixmap: vec![],
             title: "kcshot".into(),
-            description: "".into(),
+            description: String::new(),
         }
     }
 }


### PR DESCRIPTION
Replaces `"".into` with `String::new()` (and removed some redundant closures that occoured as a result of this.) as it's clearer.